### PR TITLE
The output path should be an absolute path (fix #9)

### DIFF
--- a/template/config/webpack.config.browser.js
+++ b/template/config/webpack.config.browser.js
@@ -1,13 +1,14 @@
 var webpack = require('webpack')
 var merge = require('webpack-merge')
 var base = require('./webpack.config.base')
+var path = require('path')
 
 var outputFile = '{{ name }}'
 var globalName = '{{ library }}'
 
 module.exports = merge(base, {
   output: {
-    path: './dist',
+    path: path.resolve(__dirname, '../dist'),
     filename: outputFile + '.browser.js',
     library: globalName,
     libraryTarget: 'umd',

--- a/template/config/webpack.config.common.js
+++ b/template/config/webpack.config.common.js
@@ -1,13 +1,14 @@
 var webpack = require('webpack')
 var merge = require('webpack-merge')
 var base = require('./webpack.config.base')
+var path = require('path')
 
 var outputFile = '{{ name }}'
 var globalName = '{{ library }}'
 
 module.exports = merge(base, {
   output: {
-    path: __directory + '/dist',
+    path: path.resolve(__dirname, '../dist'),
     filename: outputFile + '.common.js',
     libraryTarget: 'commonjs2',
   },

--- a/template/config/webpack.config.dev.js
+++ b/template/config/webpack.config.dev.js
@@ -1,12 +1,13 @@
 var merge = require('webpack-merge')
 var base = require('./webpack.config.base')
+var path = require('path')
 
 var outputFile = '{{ name }}'
 var globalName = '{{ library }}'
 
 module.exports = merge(base, {
   output: {
-    path: './dist',
+    path: path.resolve(__dirname, '../dist'),
     filename: outputFile + '.common.js',
     library: globalName,
     libraryTarget: 'umd',


### PR DESCRIPTION
`npm run build` produces an error on my OS, because the output path (./dist) is not an absolute path.

This commit fixes the problem with `path.resolve`.