### PR TITLE
Fixes .js match for babel-loader

### DIFF
--- a/template/config/webpack.config.base.js
+++ b/template/config/webpack.config.base.js
@@ -17,7 +17,7 @@ module.exports = {
         exclude: /node_modules/,
       },
       {
-        test: /.js$/,
+        test: /\.js$/,
         use: 'babel-loader',
       },
       {


### PR DESCRIPTION
I had a heck of a time figuring out why my build process was choking on `.ejs` files :)