### PR TITLE
bugfix: enable postcss support

### DIFF
--- a/template/postcss.config.js
+++ b/template/postcss.config.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
When the generated module library is imported, the importing project sometimes enabled postcss-loader, thus result in the following error:

Module build failed: Error: No PostCSS Config found in: ./{{lib-name}}/dist
    at config.load.then (./{{working-dir}}/node_modules/postcss-load-config/src/index.js:55:15)

 @ ../{{lib-name}}/dist/{{lib-name}}.css 4:14-177 13:3-17:5 14:22-185
 @ ../{{lib-name}}/index.js
 @ ./src/router/index.js
 @ ./src/main.js

Adding an empty default config file for postcss fix that problem.